### PR TITLE
station一覧の取得を高速化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ node_modules/
 
 # dotenv environment variables file
 .env
+
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: deploy-functions
+deploy-functions:
+	firebase deploy --only functions

--- a/functions/main.py
+++ b/functions/main.py
@@ -8,6 +8,6 @@ initialize_app()
 @https_fn.on_request()
 def stations(req: https_fn.Request) -> https_fn.Response:
     db = firestore.Client(project="cheers-connect-db-sandbox")
-    list_documents = db.collection("station").list_documents()
-    dic_dict_list = [doc_ref.get().to_dict() for doc_ref in list_documents]
+    documents = db.collection("station").stream()
+    dic_dict_list = [doc.to_dict() for doc in documents]
     return https_fn.Response(dic_dict_list.__str__())


### PR DESCRIPTION
station一覧の取得が遅かったので高速化した。

* 従来の処理は下記のようになっている
  *  `list_documents()` を呼び出して `DocumentReference` のリストを取得
  * それぞれの `DocumentReference` に対して `.get()` を呼び出すことで実態を取得、これをリストに詰めて返却する
    * このとき、`.get()` を呼び出すたびにDBと通信が発生しているらしく、ここに時間がかかっていた
* `.stream()` を用いて(参照ではなく)実態のリストを取得するようにして通信回数を減らし、高速化した