### PR TITLE
stationのリストを単一のdocumentから読み取る

### DIFF
--- a/functions/main.py
+++ b/functions/main.py
@@ -8,6 +8,6 @@ initialize_app()
 @https_fn.on_request()
 def stations(req: https_fn.Request) -> https_fn.Response:
     db = firestore.Client(project="cheers-connect-db-sandbox")
-    documents = db.collection("station").stream()
-    dic_dict_list = [doc.to_dict() for doc in documents]
-    return https_fn.Response(dic_dict_list.__str__())
+    doc_ref = db.collection("station").document("station_list")
+    doc_dict = doc_ref.get().to_dict()
+    return https_fn.Response(doc_dict["station_list"].__str__())


### PR DESCRIPTION
掲題の通り。
この対応によって、firestoreの無料枠の使用分が、1アクセスあたり1回（プルリク前は1アクセスあたり600回）になった。